### PR TITLE
add meetup_api_prefix to internal.R

### DIFF
--- a/R/get_events.R
+++ b/R/get_events.R
@@ -22,7 +22,6 @@ get_events <- function(urlname, api_key, event_status = NULL) {
   if(!is.null(event_status) && !event_status %in% c("cancelled", "draft", "past", "proposed", "suggested", "upcoming")) {
     stop(sprintf("Event status %s not allowed", event_status))
   }
-  meetup_api_prefix <- "https://api.meetup.com/"
   api_url <- paste0(meetup_api_prefix, urlname, "/events")
   .fetch_results(api_url, api_key, event_status)
 }

--- a/R/get_meetup_attendees.R
+++ b/R/get_meetup_attendees.R
@@ -16,7 +16,6 @@
 #'}
 #' @export
 get_meetup_attendees <- function(urlname, api_key, event_id){
-  meetup_api_prefix <- "https://api.meetup.com/"
   api_url <- paste0(meetup_api_prefix,
                     urlname,
                     "/events/",

--- a/R/get_meetup_comments.R
+++ b/R/get_meetup_comments.R
@@ -16,7 +16,6 @@
 #'}
 #' @export
 get_meetup_comments <- function(urlname, api_key, event_id){
-  meetup_api_prefix <- "https://api.meetup.com/"
   api_url <- paste0(meetup_api_prefix, urlname, "/events/", event_id, "/comments")
   .fetch_results(api_url, api_key)
 }

--- a/R/get_members.R
+++ b/R/get_members.R
@@ -11,7 +11,6 @@
 #'}
 #' @export
 get_members <- function(urlname, api_key){
-  meetup_api_prefix <- "https://api.meetup.com/"
   api_url <- paste0(meetup_api_prefix, urlname, "/members/")
   .fetch_results(api_url, api_key)
 }

--- a/R/internals.R
+++ b/R/internals.R
@@ -1,3 +1,5 @@
+#set meetup api prefix for all functions
+meetup_api_prefix <- "https://api.meetup.com/"
 
 .quick_fetch <- function(api_url,
                          api_key,


### PR DESCRIPTION
removed redundancy of redefining `meetup_api_prefix` in every function by moving to `internal.R` as suggested by @olgamie 