### PR TITLE
Added topic_id arg to find_groups()

### DIFF
--- a/R/find_groups.R
+++ b/R/find_groups.R
@@ -1,7 +1,7 @@
 #' Find meetup groups matching a search query
 #'
 #' @param text Character. Raw full text search query.
-#' @param topic_id  Integer. Topic ID.
+#' @param topic_id  Integer. Meetup.com topic ID.
 #' @param radius can be either "global" (default) or distance in miles in the
 #' range 0-100.
 #' @template api_key

--- a/R/find_groups.R
+++ b/R/find_groups.R
@@ -28,6 +28,7 @@
 #'
 #' @references
 #' \url{https://www.meetup.com/meetup_api/docs/find/groups/}
+#' \url{https://www.meetup.com/meetup_api/docs/find/topics/}
 #'@examples
 #' \dontrun{
 #' api_key <- Sys.getenv("MEETUP_KEY")

--- a/R/find_groups.R
+++ b/R/find_groups.R
@@ -1,6 +1,7 @@
-#' Find meetup groups using text-based search
+#' Find meetup groups matching a search query
 #'
-#' @param text string used to filter groups
+#' @param text Character. Raw full text search query.
+#' @param topic_id  Integer. Topic ID.
 #' @param radius can be either "global" (default) or distance in miles in the
 #' range 0-100.
 #' @template api_key
@@ -33,11 +34,12 @@
 #' groups <- find_groups(text = "r-ladies", api_key = api_key)
 #'}
 #' @export
-find_groups <- function(text = NULL, radius = "global", api_key = NULL) {
+find_groups <- function(text = NULL, topic_id = NULL, radius = "global", api_key = NULL) {
   api_method <- "find/groups"
   res <- .fetch_results(api_method = api_method,
                         api_key = api_key,
                         text = text,
+                        topic_id = topic_id,
                         radius = radius)
   tibble::tibble(
     id = purrr::map_int(res, "id"),

--- a/R/find_groups.R
+++ b/R/find_groups.R
@@ -33,6 +33,7 @@
 #' \dontrun{
 #' api_key <- Sys.getenv("MEETUP_KEY")
 #' groups <- find_groups(text = "r-ladies", api_key = api_key)
+#' groups <- find_groups(topic_id = 1513883, api_key = api_key)
 #'}
 #' @export
 find_groups <- function(text = NULL, topic_id = NULL, radius = "global", api_key = NULL) {

--- a/man/find_groups.Rd
+++ b/man/find_groups.Rd
@@ -2,12 +2,15 @@
 % Please edit documentation in R/find_groups.R
 \name{find_groups}
 \alias{find_groups}
-\title{Find meetup groups using text-based search}
+\title{Find meetup groups matching a search query}
 \usage{
-find_groups(text = NULL, radius = "global", api_key = NULL)
+find_groups(text = NULL, topic_id = NULL, radius = "global",
+  api_key = NULL)
 }
 \arguments{
-\item{text}{string used to filter groups}
+\item{text}{Character. Raw full text search query.}
+
+\item{topic_id}{Integer. Topic ID.}
 
 \item{radius}{can be either "global" (default) or distance in miles in the
 range 0-100.}
@@ -41,7 +44,7 @@ A tibble with the following columns:
 }
 }
 \description{
-Find meetup groups using text-based search
+Find meetup groups matching a search query
 }
 \examples{
 \dontrun{

--- a/man/find_groups.Rd
+++ b/man/find_groups.Rd
@@ -50,6 +50,7 @@ Find meetup groups matching a search query
 \dontrun{
 api_key <- Sys.getenv("MEETUP_KEY")
 groups <- find_groups(text = "r-ladies", api_key = api_key)
+groups <- find_groups(topic_id = 1513883, api_key = api_key)  
 }
 }
 \references{

--- a/man/find_groups.Rd
+++ b/man/find_groups.Rd
@@ -10,7 +10,7 @@ find_groups(text = NULL, topic_id = NULL, radius = "global",
 \arguments{
 \item{text}{Character. Raw full text search query.}
 
-\item{topic_id}{Integer. Topic ID.}
+\item{topic_id}{Integer. Meetup.com topic ID.}
 
 \item{radius}{can be either "global" (default) or distance in miles in the
 range 0-100.}


### PR DESCRIPTION
Add `topic_id` argument to `find_groups()` function: https://github.com/rladies/meetupr/issues/13.  Currently `topic_id` expects a single integer. (note: "R-Ladies" topic id is 1513883)
