### PR TITLE
get_event_attendees error message and documentation + README for past events

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,14 +1,15 @@
 Package: meetupr
 Type: Package
 Title: Meetup R API
-Version: 0.1.1
-Date: 2018-02-18
+Version: 0.1.2
+Date: 2018-03-03
 Authors@R: c(person("Gabriela", "De Queiroz", email = "gabriela@rladies.org", role = c("aut")),
              person("Erin", "LeDell", email = "oss@ledell.org", role = c("aut", "cre")),
              person("Olga", "Mierzwa-Sulima", email = "olga@rladies.org", role = c("aut")),
              person("Lucy", "D'Agostino McGowan", email = "lucy@rladies.org", role = c("aut")),
              person("Claudia", "Vitolo", role = c("aut")),
-             person("Michael", "Beigelmacher", role = c("ctb")))
+             person("Michael", "Beigelmacher", role = c("ctb")),
+             person("Rick", "Pack", email = "rickeyhp@gmail.com", role = c("ctb")))
 Description: Provides access to data from 'meetup.com' (see https://www.meetup.com/meetup_api/ for more information).
 License: MIT + file LICENSE
 Depends:

--- a/R/get_event_attendees.R
+++ b/R/get_event_attendees.R
@@ -1,6 +1,5 @@
 #' Get the attendees for a specified event
 #'
-#' Must be an administrator of the queried Meetup group because of Meetup.com API restriction on get_event_attendees
 #' @template urlname
 #' @param event_id Character. The id of the event. Event ids can be obtained
 #'   using [get_events()] or by looking at the event page URL.

--- a/R/get_event_attendees.R
+++ b/R/get_event_attendees.R
@@ -1,5 +1,6 @@
 #' Get the attendees for a specified event
 #'
+#' Must be an administrator of the queried Meetup group because of Meetup.com API restriction on get_event_attendees
 #' @template urlname
 #' @param event_id Character. The id of the event. Event ids can be obtained
 #'   using [get_events()] or by looking at the event page URL.
@@ -23,9 +24,9 @@
 #' @export
 get_event_attendees <- function(urlname, event_id, api_key = NULL) {
   api_method <- paste0(urlname,
-                    "/events/",
-                    event_id,
-                    "/attendance")
+                       "/events/",
+                       event_id,
+                       "/attendance")
   res <- .fetch_results(api_method, api_key)
   tibble::tibble(
     id = purrr::map_int(res, c("member", "id")),

--- a/R/internals.R
+++ b/R/internals.R
@@ -14,7 +14,7 @@
 
   req <- httr::GET(url = api_url,          # the endpoint
                    query = parameters)
-  if(req$status_code == 400) {
+  if (req$status_code == 400) {
     stop(paste0("HTTP 400 error encountered. Note for some endpoints",
                 " the Meetup API requires you to be the respective",
                 " group’s administrator"))

--- a/R/internals.R
+++ b/R/internals.R
@@ -17,7 +17,7 @@
   if (req$status_code == 400) {
     stop(paste0("HTTP 400 error encountered. Note for some endpoints",
                 " the Meetup API requires you to be the respective",
-                " group’s administrator"))
+                " group’s administrator."))
   }
   httr::stop_for_status(req)
   reslist <- httr::content(req, "parsed")

--- a/R/internals.R
+++ b/R/internals.R
@@ -15,9 +15,7 @@
   req <- httr::GET(url = api_url,          # the endpoint
                    query = parameters)
   if (req$status_code == 400) {
-    stop(paste0("HTTP 400 error encountered. Note for some endpoints",
-                " the Meetup API requires you to be the respective",
-                " group’s administrator."))
+    stop(paste0("HTTP 400 error encountered. Note for some endpoints", " the Meetup API requires you to be the respective", " group’s administrator."))
   }
   httr::stop_for_status(req)
   reslist <- httr::content(req, "parsed")

--- a/R/internals.R
+++ b/R/internals.R
@@ -15,7 +15,10 @@
   req <- httr::GET(url = api_url,          # the endpoint
                    query = parameters)
   if (req$status_code == 400) {
-    stop(paste0("HTTP 400 error encountered. Note for some endpoints", " the Meetup API requires you to be the respective", " group’s administrator."))
+    stop(paste0("HTTP 400 error encountered.",
+                " Note for some endpoints",
+                " the Meetup API requires you to be the respective",
+                " group’s administrator."))
   }
   httr::stop_for_status(req)
   reslist <- httr::content(req, "parsed")

--- a/R/internals.R
+++ b/R/internals.R
@@ -15,6 +15,116 @@
   req <- httr::GET(url = api_url,          # the endpoint
                    query = parameters)
 
+  if(req$status_code == 400){
+    stop(paste0("HTTP 400 error encountered. Might you have requested",
+                " data for which the Meetup API requires that you be",
+                " the respective group's administrator (e.g., event",
+                " attendee data)?"))
+  }
+  httr::stop_for_status(req)
+  reslist <- httr::content(req, "parsed")
+
+  if (length(reslist) == 0) {
+    stop("Zero records match your filter. Nothing to return.\n",
+         call. = FALSE)
+  }
+
+  return(list(result = reslist, headers = req$headers))
+}
+
+
+# Fetch all the results of a query given an API Method
+# Will make multiple calls to the API if needed
+# API Methods listed here: https://www.meetup.com/meetup_api/docs/
+.fetch_results <- function(api_method, api_key = NULL, event_status = NULL, ...) {
+
+  # Build the API endpoint URL
+  meetup_api_prefix <- "https://api.meetup.com/"
+  api_url <- paste0(meetup_api_prefix, api_method)
+
+  # Get the API key from MEETUP_KEY environment variable if NULL
+  if (is.null(api_key)) api_key <- .get_api_key()
+  if (!is.character(api_key)) stop("api_key must be a character string")
+
+  # Fetch first set of results (limited to 200 records each call)
+  res <- .quick_fetch(api_url = api_url,
+                      api_key = api_key,
+                      event_status = event_status,
+                      ...)
+
+  # Total number of records matching the query
+  total_records <- as.integer(res$headers$`x-total-count`)
+  if (length(total_records) == 0) total_records <- 1L
+  records <- res$result
+  cat(paste("Downloading", total_records, "record(s)..."))
+
+  # If you have not yet retrieved all records, calculate the # of remaining calls required
+  extra_calls <- ifelse(
+    (length(records) < total_records) & !is.null(res$headers$link),
+    floor(total_records/length(records)),
+    0)
+  if (extra_calls > 0) {
+    all_records <- list(records)
+    for (i in seq(extra_calls)) {
+      # Keep making API requests with an increasing offset value until you get all the records
+      # TO DO: clean this strsplit up or replace with regex
+
+      next_url <- strsplit(strsplit(res$headers$link, split = "<")[[1]][2], split = ">")[[1]][1]
+      res <- .quick_fetch(next_url, api_key, event_status)
+      all_records[[i + 1]] <- res$result
+    }
+    records <- unlist(all_records, recursive = FALSE)
+  }
+
+  return(records)
+}
+
+
+# helper function to convert a vector of milliseconds since epoch into POSIXct
+.date_helper <- function(time) {
+  if (is.character(time)) {
+    # if date is character string, try to convert to numeric
+    time <- tryCatch(expr = as.numeric(time),
+                     error = warning("One or more dates could not be converted properly"))
+  }
+  if (is.numeric(time)) {
+    # divide milliseconds by 1000 to get seconds; convert to POSIXct
+    seconds <- time / 1000
+    out <- as.POSIXct(seconds, origin = "1970-01-01")
+  } else {
+    # if no conversion can be done, then return NA
+    warning("One or more dates could not be converted properly")
+    out <- rep(NA, length(time))
+  }
+  return(out)
+}
+
+# function to return meetup.com API key stored in the MEETUP_KEY environment variable
+.get_api_key <- function() {
+  api_key <- Sys.getenv("MEETUP_KEY")
+  if (api_key == "") {
+    stop("You have not set a MEETUP_KEY environment variable.\nIf you do not yet have a meetup.com API key, you can retrieve one here:\n  * https://secure.meetup.com/meetup_api/key/",
+         call. = FALSE)
+  }
+  return(api_key)
+}
+# This helper function makes a single call, given the full API endpoint URL
+# Used as the workhorse function inside .fetch_results() below
+.quick_fetch <- function(api_url,
+                         api_key = NULL,
+                         event_status = NULL,
+                         ...) {
+
+  # list of parameters
+  parameters <- list(key = api_key,         # your api_key
+                     status = event_status, # you need to add the status
+                     # otherwise it will get only the upcoming event
+                     ...                    # other parameters
+  )
+
+  req <- httr::GET(url = api_url,          # the endpoint
+                   query = parameters)
+
   httr::stop_for_status(req)
   reslist <- httr::content(req, "parsed")
 

--- a/R/internals.R
+++ b/R/internals.R
@@ -14,11 +14,10 @@
 
   req <- httr::GET(url = api_url,          # the endpoint
                    query = parameters)
-  if(req$status_code == 400){
-    stop(paste0("HTTP 400 error encountered. Might you have requested",
-                " data for which the Meetup API requires that you be",
-                " the respective group's administrator (e.g., event",
-                " attendee data)?"))
+  if(req$status_code == 400) {
+    stop(paste0("HTTP 400 error encountered. Note for some endpoints",
+                " the Meetup API requires you to be the respective",
+                " group’s administrator"))
   }
   httr::stop_for_status(req)
   reslist <- httr::content(req, "parsed")

--- a/R/internals.R
+++ b/R/internals.R
@@ -14,117 +14,12 @@
 
   req <- httr::GET(url = api_url,          # the endpoint
                    query = parameters)
-
   if(req$status_code == 400){
     stop(paste0("HTTP 400 error encountered. Might you have requested",
                 " data for which the Meetup API requires that you be",
                 " the respective group's administrator (e.g., event",
                 " attendee data)?"))
   }
-  httr::stop_for_status(req)
-  reslist <- httr::content(req, "parsed")
-
-  if (length(reslist) == 0) {
-    stop("Zero records match your filter. Nothing to return.\n",
-         call. = FALSE)
-  }
-
-  return(list(result = reslist, headers = req$headers))
-}
-
-
-# Fetch all the results of a query given an API Method
-# Will make multiple calls to the API if needed
-# API Methods listed here: https://www.meetup.com/meetup_api/docs/
-.fetch_results <- function(api_method, api_key = NULL, event_status = NULL, ...) {
-
-  # Build the API endpoint URL
-  meetup_api_prefix <- "https://api.meetup.com/"
-  api_url <- paste0(meetup_api_prefix, api_method)
-
-  # Get the API key from MEETUP_KEY environment variable if NULL
-  if (is.null(api_key)) api_key <- .get_api_key()
-  if (!is.character(api_key)) stop("api_key must be a character string")
-
-  # Fetch first set of results (limited to 200 records each call)
-  res <- .quick_fetch(api_url = api_url,
-                      api_key = api_key,
-                      event_status = event_status,
-                      ...)
-
-  # Total number of records matching the query
-  total_records <- as.integer(res$headers$`x-total-count`)
-  if (length(total_records) == 0) total_records <- 1L
-  records <- res$result
-  cat(paste("Downloading", total_records, "record(s)..."))
-
-  # If you have not yet retrieved all records, calculate the # of remaining calls required
-  extra_calls <- ifelse(
-    (length(records) < total_records) & !is.null(res$headers$link),
-    floor(total_records/length(records)),
-    0)
-  if (extra_calls > 0) {
-    all_records <- list(records)
-    for (i in seq(extra_calls)) {
-      # Keep making API requests with an increasing offset value until you get all the records
-      # TO DO: clean this strsplit up or replace with regex
-
-      next_url <- strsplit(strsplit(res$headers$link, split = "<")[[1]][2], split = ">")[[1]][1]
-      res <- .quick_fetch(next_url, api_key, event_status)
-      all_records[[i + 1]] <- res$result
-    }
-    records <- unlist(all_records, recursive = FALSE)
-  }
-
-  return(records)
-}
-
-
-# helper function to convert a vector of milliseconds since epoch into POSIXct
-.date_helper <- function(time) {
-  if (is.character(time)) {
-    # if date is character string, try to convert to numeric
-    time <- tryCatch(expr = as.numeric(time),
-                     error = warning("One or more dates could not be converted properly"))
-  }
-  if (is.numeric(time)) {
-    # divide milliseconds by 1000 to get seconds; convert to POSIXct
-    seconds <- time / 1000
-    out <- as.POSIXct(seconds, origin = "1970-01-01")
-  } else {
-    # if no conversion can be done, then return NA
-    warning("One or more dates could not be converted properly")
-    out <- rep(NA, length(time))
-  }
-  return(out)
-}
-
-# function to return meetup.com API key stored in the MEETUP_KEY environment variable
-.get_api_key <- function() {
-  api_key <- Sys.getenv("MEETUP_KEY")
-  if (api_key == "") {
-    stop("You have not set a MEETUP_KEY environment variable.\nIf you do not yet have a meetup.com API key, you can retrieve one here:\n  * https://secure.meetup.com/meetup_api/key/",
-         call. = FALSE)
-  }
-  return(api_key)
-}
-# This helper function makes a single call, given the full API endpoint URL
-# Used as the workhorse function inside .fetch_results() below
-.quick_fetch <- function(api_url,
-                         api_key = NULL,
-                         event_status = NULL,
-                         ...) {
-
-  # list of parameters
-  parameters <- list(key = api_key,         # your api_key
-                     status = event_status, # you need to add the status
-                     # otherwise it will get only the upcoming event
-                     ...                    # other parameters
-  )
-
-  req <- httr::GET(url = api_url,          # the endpoint
-                   query = parameters)
-
   httr::stop_for_status(req)
   reslist <- httr::content(req, "parsed")
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -49,18 +49,18 @@ We currently have the following functions:
 * `get_members()`
 * `get_boards()`
 * `get_events()`  
-* `get_event_attendees()`  
+* `get_event_attendees()` *Note: Must be a Meetup group administrator to use because of API restriction.
 * `get_event_comments()`
-* `get_event_rsvps()`
+* `get_event_rsvps()` 
 * `find_groups()`
 
-Each will output a tibble with information extracted into from the API as well as a `list-col` named `*_resource` with all API output. For example, the following code will get all upcoming events for the [RLadies Nashville](https://meetup.com/rladies-nashville) meetup.
+Each will output a tibble with information extracted into from the API as well as a `list-col` named `*_resource` with all API output. For example, the following code will get all past events for the [RLadies Nashville](https://meetup.com/rladies-nashville) meetup.
 
 ```{r}
 library(meetupr)
 
 urlname <- "rladies-nashville"
-(events <- get_events(urlname))
+(events <- get_events(urlname, event_status = "past"))
 ```
 
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -19,7 +19,7 @@ knitr::opts_chunk$set(
 
 R interface to the Meetup API (v3)
 
-**Authors:** [Gabriela de Queiroz](http://gdequeiroz.github.io/), [Erin LeDell](http://www.stat.berkeley.edu/~ledell/), [Olga Mierzwa-Sulima](https://github.com/olgamie), [Lucy D'Agostino McGowan](http://www.lucymcgowan.com), [Claudia Vitolo](https://github.com/cvitolo)<br/> [MIT](https://opensource.org/licenses/MIT)
+**Authors:** [Gabriela de Queiroz](http://gdequeiroz.github.io/), [Erin LeDell](http://www.stat.berkeley.edu/~ledell/), [Olga Mierzwa-Sulima](https://github.com/olgamie), [Lucy D'Agostino McGowan](http://www.lucymcgowan.com), [Claudia Vitolo](https://github.com/cvitolo)<br/>, [MIT](https://opensource.org/licenses/MIT)
 **License:** [MIT](https://opensource.org/licenses/MIT)
 
 ## Installation

--- a/README.Rmd
+++ b/README.Rmd
@@ -76,6 +76,6 @@ In order to run our tests, you will have to set the `urlname` for meetup you bel
 Sys.setenv(MEETUP_NAME = "YOUR MEETUP NAME")
 ```
 
-### TO DO:
+### TODO:
 - add tests
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -76,6 +76,6 @@ In order to run our tests, you will have to set the `urlname` for meetup you bel
 Sys.setenv(MEETUP_NAME = "YOUR MEETUP NAME")
 ```
 
-### TODO:
+### TO DO:
 - add tests
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -19,7 +19,7 @@ knitr::opts_chunk$set(
 
 R interface to the Meetup API (v3)
 
-**Authors:** [Gabriela de Queiroz](http://gdequeiroz.github.io/), [Erin LeDell](http://www.stat.berkeley.edu/~ledell/), [Olga Mierzwa-Sulima](https://github.com/olgamie), [Lucy D'Agostino McGowan](http://www.lucymcgowan.com), [Claudia Vitolo](https://github.com/cvitolo)<br/>, [MIT](https://opensource.org/licenses/MIT)
+**Authors:** [Gabriela de Queiroz](http://gdequeiroz.github.io/), [Erin LeDell](http://www.stat.berkeley.edu/~ledell/), [Olga Mierzwa-Sulima](https://github.com/olgamie), [Lucy D'Agostino McGowan](http://www.lucymcgowan.com), [Claudia Vitolo](https://github.com/cvitolo)<br/>
 **License:** [MIT](https://opensource.org/licenses/MIT)
 
 ## Installation
@@ -49,7 +49,7 @@ We currently have the following functions:
 * `get_members()`
 * `get_boards()`
 * `get_events()`  
-* `get_event_attendees()` *Note: Must be a Meetup group administrator to use because of API restriction.
+* `get_event_attendees()` 
 * `get_event_comments()`
 * `get_event_rsvps()` 
 * `find_groups()`
@@ -60,7 +60,7 @@ Each will output a tibble with information extracted into from the API as well a
 library(meetupr)
 
 urlname <- "rladies-nashville"
-(events <- get_events(urlname, event_status = "past"))
+events <- get_events(urlname, event_status = "past")
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -7,18 +7,18 @@ meetupr
 
 R interface to the Meetup API (v3)
 
-**Authors:** [Gabriela de Queiroz](http://gdequeiroz.github.io/), [Erin LeDell](http://www.stat.berkeley.edu/~ledell/), [Olga Mierzwa-Sulima](https://github.com/olgamie), [Lucy D'Agostino McGowan](http://www.lucymcgowan.com), [Claudia Vitolo](https://github.com/cvitolo)<br/> **License:** [MIT](https://opensource.org/licenses/MIT)
+**Authors:** [Gabriela de Queiroz](http://gdequeiroz.github.io/), [Erin LeDell](http://www.stat.berkeley.edu/~ledell/), [Olga Mierzwa-Sulima](https://github.com/olgamie), [Lucy D'Agostino McGowan](http://www.lucymcgowan.com), [Claudia Vitolo](https://github.com/cvitolo)<br/> [MIT](https://opensource.org/licenses/MIT) **License:** [MIT](https://opensource.org/licenses/MIT)
 
 Installation
 ------------
 
 To install the development version from GitHub:
 
-```{r}
+``` r
 # install.packages("devtools")
-library(devtools)
 devtools::install_github("rladies/meetupr")
 ```
+
 A released version will be on CRAN soon.
 
 Usage
@@ -39,24 +39,36 @@ We currently have the following functions:
 -   `get_members()`
 -   `get_boards()`
 -   `get_events()`
--   `get_event_attendees()`
+-   `get_event_attendees()` \*Note: Must be a Meetup group administrator to use because of API restriction.
 -   `get_event_comments()`
--   `get_event_rsvps()`   
+-   `get_event_rsvps()`
 -   `find_groups()`
 
-Each will output a tibble with information extracted into from the API as well as a `list-col` named `*_resource` with all API output. For example, the following code will get all upcoming events for the [RLadies Nashville](https://meetup.com/rladies-nashville) meetup.
+Each will output a tibble with information extracted into from the API as well as a `list-col` named `*_resource` with all API output. For example, the following code will get all past events for the [RLadies Nashville](https://meetup.com/rladies-nashville) meetup.
 
 ``` r
 library(meetupr)
 
 urlname <- "rladies-nashville"
-(events <- get_events(urlname))
-#> # A tibble: 2 x 5
-#>          id                    name yes_rsvp_count                time
-#>       <chr>                   <chr>          <int>              <dttm>
-#> 1 243331077   Introduction to purrr             11 2017-11-14 00:00:00
-#> 2 243331084 TBA with Laurie Samuels              5 2017-12-01 18:00:00
-#> # ... with 1 more variables: resource <list>
+(events <- get_events(urlname, event_status = "past"))
+#> Downloading 9 record(s)...
+#> # A tibble: 9 x 21
+#>   id     name    created             status time                local_date
+#>   <chr>  <chr>   <dttm>              <chr>  <dttm>              <date>    
+#> 1 23496… R-Ladi… 2016-10-19 11:52:17 past   2016-11-07 18:30:00 2016-11-07
+#> 2 23565… Decemb… 2016-11-17 14:11:58 past   2016-12-06 13:15:00 2016-12-06
+#> 3 23575… Januar… 2016-11-22 11:27:58 past   2017-01-10 19:00:00 2017-01-10
+#> 4 23705… Februa… 2017-01-19 17:29:02 past   2017-02-10 13:15:00 2017-02-10
+#> 5 23705… March … 2017-01-19 17:36:31 past   2017-03-21 19:00:00 2017-03-21
+#> 6 23993… An R +… 2017-05-12 12:21:43 past   2017-05-30 13:00:00 2017-05-30
+#> 7 24209… Workin… 2017-07-28 15:29:41 past   2017-09-12 19:00:00 2017-09-12
+#> 8 24333… Introd… 2017-09-13 10:42:01 past   2017-11-13 19:00:00 2017-11-13
+#> 9 24333… Play i… 2017-09-13 10:42:51 past   2017-12-01 13:00:00 2017-12-01
+#> # ... with 15 more variables: local_time <chr>, waitlist_count <int>,
+#> #   yes_rsvp_count <int>, venue_id <int>, venue_name <chr>,
+#> #   venue_lat <dbl>, venue_lon <dbl>, venue_address_1 <chr>,
+#> #   venue_city <chr>, venue_state <chr>, venue_zip <chr>,
+#> #   venue_country <chr>, description <chr>, link <chr>, resource <list>
 ```
 
 How can you contribute?
@@ -73,6 +85,6 @@ In order to run our tests, you will have to set the `urlname` for meetup you bel
 Sys.setenv(MEETUP_NAME = "YOUR MEETUP NAME")
 ```
 
-### TO DO:
+### TODO:
 
 -   add tests

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ meetupr
 
 R interface to the Meetup API (v3)
 
-**Authors:** [Gabriela de Queiroz](http://gdequeiroz.github.io/), [Erin LeDell](http://www.stat.berkeley.edu/~ledell/), [Olga Mierzwa-Sulima](https://github.com/olgamie), [Lucy D'Agostino McGowan](http://www.lucymcgowan.com), [Claudia Vitolo](https://github.com/cvitolo)<br/> [MIT](https://opensource.org/licenses/MIT) **License:** [MIT](https://opensource.org/licenses/MIT)
+**Authors:** [Gabriela de Queiroz](http://gdequeiroz.github.io/), [Erin LeDell](http://www.stat.berkeley.edu/~ledell/), [Olga Mierzwa-Sulima](https://github.com/olgamie), [Lucy D'Agostino McGowan](http://www.lucymcgowan.com), [Claudia Vitolo](https://github.com/cvitolo)<br/>, [MIT](https://opensource.org/licenses/MIT) **License:** [MIT](https://opensource.org/licenses/MIT)
 
 Installation
 ------------

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ meetupr
 
 R interface to the Meetup API (v3)
 
-**Authors:** [Gabriela de Queiroz](http://gdequeiroz.github.io/), [Erin LeDell](http://www.stat.berkeley.edu/~ledell/), [Olga Mierzwa-Sulima](https://github.com/olgamie), [Lucy D'Agostino McGowan](http://www.lucymcgowan.com), [Claudia Vitolo](https://github.com/cvitolo)<br/>, [MIT](https://opensource.org/licenses/MIT) **License:** [MIT](https://opensource.org/licenses/MIT)
+**Authors:** [Gabriela de Queiroz](http://gdequeiroz.github.io/), [Erin LeDell](http://www.stat.berkeley.edu/~ledell/), [Olga Mierzwa-Sulima](https://github.com/olgamie), [Lucy D'Agostino McGowan](http://www.lucymcgowan.com), [Claudia Vitolo](https://github.com/cvitolo)<br/> **License:** [MIT](https://opensource.org/licenses/MIT)
 
 Installation
 ------------
@@ -39,7 +39,7 @@ We currently have the following functions:
 -   `get_members()`
 -   `get_boards()`
 -   `get_events()`
--   `get_event_attendees()` \*Note: Must be a Meetup group administrator to use because of API restriction.
+-   `get_event_attendees()`
 -   `get_event_comments()`
 -   `get_event_rsvps()`
 -   `find_groups()`
@@ -50,25 +50,8 @@ Each will output a tibble with information extracted into from the API as well a
 library(meetupr)
 
 urlname <- "rladies-nashville"
-(events <- get_events(urlname, event_status = "past"))
+events <- get_events(urlname, event_status = "past")
 #> Downloading 9 record(s)...
-#> # A tibble: 9 x 21
-#>   id     name    created             status time                local_date
-#>   <chr>  <chr>   <dttm>              <chr>  <dttm>              <date>    
-#> 1 23496… R-Ladi… 2016-10-19 11:52:17 past   2016-11-07 18:30:00 2016-11-07
-#> 2 23565… Decemb… 2016-11-17 14:11:58 past   2016-12-06 13:15:00 2016-12-06
-#> 3 23575… Januar… 2016-11-22 11:27:58 past   2017-01-10 19:00:00 2017-01-10
-#> 4 23705… Februa… 2017-01-19 17:29:02 past   2017-02-10 13:15:00 2017-02-10
-#> 5 23705… March … 2017-01-19 17:36:31 past   2017-03-21 19:00:00 2017-03-21
-#> 6 23993… An R +… 2017-05-12 12:21:43 past   2017-05-30 13:00:00 2017-05-30
-#> 7 24209… Workin… 2017-07-28 15:29:41 past   2017-09-12 19:00:00 2017-09-12
-#> 8 24333… Introd… 2017-09-13 10:42:01 past   2017-11-13 19:00:00 2017-11-13
-#> 9 24333… Play i… 2017-09-13 10:42:51 past   2017-12-01 13:00:00 2017-12-01
-#> # ... with 15 more variables: local_time <chr>, waitlist_count <int>,
-#> #   yes_rsvp_count <int>, venue_id <int>, venue_name <chr>,
-#> #   venue_lat <dbl>, venue_lon <dbl>, venue_address_1 <chr>,
-#> #   venue_city <chr>, venue_state <chr>, venue_zip <chr>,
-#> #   venue_country <chr>, description <chr>, link <chr>, resource <list>
 ```
 
 How can you contribute?

--- a/man/get_boards.Rd
+++ b/man/get_boards.Rd
@@ -7,7 +7,7 @@
 get_boards(urlname, api_key)
 }
 \arguments{
-\item{urlname}{Character. The name of the group as indicicated in the
+\item{urlname}{Character. The name of the group as indicated in the
 \url{https://meetup.com} url.}
 
 \item{api_key}{Character. Your api key. Defaults to checking your environment

--- a/man/get_event_attendees.Rd
+++ b/man/get_event_attendees.Rd
@@ -28,7 +28,7 @@ A tibble with the following columns:
 }
 }
 \description{
-Get the attendees for a specified event
+Must be an administrator of the queried Meetup group because of Meetup.com API restriction on get_event_attendees
 }
 \examples{
 \dontrun{

--- a/man/get_event_attendees.Rd
+++ b/man/get_event_attendees.Rd
@@ -28,7 +28,7 @@ A tibble with the following columns:
 }
 }
 \description{
-Must be an administrator of the queried Meetup group because of Meetup.com API restriction on get_event_attendees
+Get the attendees for a specified event
 }
 \examples{
 \dontrun{

--- a/man/get_event_comments.Rd
+++ b/man/get_event_comments.Rd
@@ -7,7 +7,7 @@
 get_event_comments(urlname, event_id, api_key = NULL)
 }
 \arguments{
-\item{urlname}{Character. The name of the group as indicicated in the
+\item{urlname}{Character. The name of the group as indicated in the
 \url{https://meetup.com} url.}
 
 \item{event_id}{Character. The id of the event. Event ids can be obtained

--- a/man/get_event_rsvps.Rd
+++ b/man/get_event_rsvps.Rd
@@ -7,7 +7,7 @@
 get_event_rsvps(urlname, event_id, api_key = NULL)
 }
 \arguments{
-\item{urlname}{Character. The name of the group as indicicated in the
+\item{urlname}{Character. The name of the group as indicated in the
 \url{https://meetup.com} url.}
 
 \item{event_id}{Character. The id of the event. Event ids can be obtained
@@ -23,11 +23,11 @@ A tibble with the following columns:
 \itemize{
 \item member_id
 \item member_name
+\item member_is_host
 \item response
 \item guests
 \item created
 \item updated
-\item member_is_host
 \item resource
 }
 }
@@ -38,7 +38,7 @@ Get the RSVPs for a specified event
 \dontrun{
 urlname <- "rladies-nashville"
 upcoming_events <- get_events(urlname = urlname,
-                      event_status = "upcoming")
+                      event_status = "past")
 event_id <- upcoming_events$id[1]  #first event for this group
 rsvps <- get_event_rsvps(urlname, event_id)
 }

--- a/man/get_events.Rd
+++ b/man/get_events.Rd
@@ -7,7 +7,7 @@
 get_events(urlname, event_status = "upcoming", api_key = NULL)
 }
 \arguments{
-\item{urlname}{Character. The name of the group as indicicated in the
+\item{urlname}{Character. The name of the group as indicated in the
 \url{https://meetup.com} url.}
 
 \item{event_status}{Character or character vector (e.g. "upcoming" or c("past", "upcoming")). Event type - defaults to "upcoming".

--- a/man/get_members.Rd
+++ b/man/get_members.Rd
@@ -7,7 +7,7 @@
 get_members(urlname, api_key = NULL)
 }
 \arguments{
-\item{urlname}{Character. The name of the group as indicicated in the
+\item{urlname}{Character. The name of the group as indicated in the
 \url{https://meetup.com} url.}
 
 \item{api_key}{Character. Your api key. Defaults to checking your environment


### PR DESCRIPTION
For Issue #22  @ledell 
Internals.R: Custom get_event_attendees error message to indicate user must be a group administration to use htis function due to Meetup API restriction. Updated .R and README documentation for function. 
Also README updated to show past events because query returned 0 records this weekend (no planned events, which is the default argument).

The change to the README authors in the MD file appears to be because it had previously not been knit after the addition of MIT, and I added a comma before that interest in the author sequence. The single-word usage of "TODO" appeared to have also not been previously knit.