### PR TITLE
handle edge cases; group has no organizer, old events

### DIFF
--- a/R/find_groups.R
+++ b/R/find_groups.R
@@ -50,13 +50,13 @@ find_groups <- function(text = NULL, radius = "global", api_key = NULL) {
     lat = purrr::map_dbl(res, "lat"),
     lon = purrr::map_dbl(res, "lon"),
     city = purrr::map_chr(res, "city"),
-    state = purrr::map_chr(res, "state", .null = NA),
+    state = purrr::map_chr(res, "state",, .default = NA),
     country = purrr::map_chr(res, "country"),
-    timezone = purrr::map_chr(res, "timezone", .null = NA),
+    timezone = purrr::map_chr(res, "timezone", .default = NA),
     organizer_id = purrr::map_int(res, c("organizer", "id"), .default = NA),
     organizer_name = purrr::map_chr(res, c("organizer", "name"), .default = NA),
-    category_id = purrr::map_int(res, c("category", "id"), .null = NA),
-    category_name = purrr::map_chr(res, c("category", "name"), .null = NA),
+    category_id = purrr::map_int(res, c("category", "id"), .default = NA),
+    category_name = purrr::map_chr(res, c("category", "name"), .default = NA),
     resource = res
   )
 }

--- a/R/find_groups.R
+++ b/R/find_groups.R
@@ -53,8 +53,8 @@ find_groups <- function(text = NULL, radius = "global", api_key = NULL) {
     state = purrr::map_chr(res, "state", .null = NA),
     country = purrr::map_chr(res, "country"),
     timezone = purrr::map_chr(res, "timezone", .null = NA),
-    organizer_id = purrr::map_int(res, c("organizer", "id")),
-    organizer_name = purrr::map_chr(res, c("organizer", "name")),
+    organizer_id = purrr::map_int(res, c("organizer", "id"), .default = NA),
+    organizer_name = purrr::map_chr(res, c("organizer", "name"), .default = NA),
     category_id = purrr::map_int(res, c("category", "id"), .null = NA),
     category_name = purrr::map_chr(res, c("category", "name"), .null = NA),
     resource = res

--- a/R/find_groups.R
+++ b/R/find_groups.R
@@ -46,7 +46,7 @@ find_groups <- function(text = NULL, radius = "global", api_key = NULL) {
     created = .date_helper(purrr::map_dbl(res, "created")),
     members = purrr::map_int(res, "members"),
     status = purrr::map_chr(res, "status"),
-    organizer = purrr::map_chr(res, c("organizer", "name")),
+    organizer = purrr::map_chr(res, c("organizer", "name"), .default = NA),
     lat = purrr::map_dbl(res, "lat"),
     lon = purrr::map_dbl(res, "lon"),
     city = purrr::map_chr(res, "city"),

--- a/R/get_events.R
+++ b/R/get_events.R
@@ -63,7 +63,7 @@ get_events <- function(urlname, event_status = "upcoming", api_key = NULL) {
     created = .date_helper(purrr::map_dbl(res, "created", .default = NA)),
     status = purrr::map_chr(res, "status", .default = NA),
     time = .date_helper(purrr::map_dbl(res, "time", .default = NA)),
-    local_date = as.Date(purrr::map_chr(res, "local_date"), .default = NA),
+    local_date = as.Date(purrr::map_chr(res, "local_date", .default = NA)),
     local_time = purrr::map_chr(res, "local_time", .default = NA),
     # TO DO: Add a local_datetime combining the two above?
     waitlist_count = purrr::map_int(res, "waitlist_count", .default = NA),

--- a/R/get_events.R
+++ b/R/get_events.R
@@ -58,27 +58,27 @@ get_events <- function(urlname, event_status = "upcoming", api_key = NULL) {
   api_method <- paste0(urlname, "/events")
   res <- .fetch_results(api_method, api_key, event_status)
   tibble::tibble(
-    id = purrr::map_chr(res, "id"),  #this is returned as chr (not int)
-    name = purrr::map_chr(res, "name"),
-    created = .date_helper(purrr::map_dbl(res, "created")),
-    status = purrr::map_chr(res, "status"),
-    time = .date_helper(purrr::map_dbl(res, "time")),
-    local_date = as.Date(purrr::map_chr(res, "local_date")),
-    local_time = purrr::map_chr(res, "local_time", .null = NA),
+    id = purrr::map_chr(res, "id", .default = NA),  #this is returned as chr (not int)
+    name = purrr::map_chr(res, "name", .default = NA),
+    created = .date_helper(purrr::map_dbl(res, "created", .default = NA)),
+    status = purrr::map_chr(res, "status", .default = NA),
+    time = .date_helper(purrr::map_dbl(res, "time", .default = NA)),
+    local_date = as.Date(purrr::map_chr(res, "local_date"), .default = NA),
+    local_time = purrr::map_chr(res, "local_time", .default = NA),
     # TO DO: Add a local_datetime combining the two above?
-    waitlist_count = purrr::map_int(res, "waitlist_count"),
-    yes_rsvp_count = purrr::map_int(res, "yes_rsvp_count"),
-    venue_id = purrr::map_int(res, c("venue", "id"), .null = NA),
-    venue_name = purrr::map_chr(res, c("venue", "name"), .null = NA),
-    venue_lat = purrr::map_dbl(res, c("venue", "lat"), .null = NA),
-    venue_lon = purrr::map_dbl(res, c("venue", "lon"), .null = NA),
-    venue_address_1 = purrr::map_chr(res, c("venue", "address_1"), .null = NA),
-    venue_city = purrr::map_chr(res, c("venue", "city"), .null = NA),
-    venue_state = purrr::map_chr(res, c("venue", "state"), .null = NA),
-    venue_zip = purrr::map_chr(res, c("venue", "zip"), .null = NA),
-    venue_country = purrr::map_chr(res, c("venue", "country"), .null = NA),
-    description = purrr::map_chr(res, c("description"), .null = NA),
-    link = purrr::map_chr(res, c("link")),
+    waitlist_count = purrr::map_int(res, "waitlist_count", .default = NA),
+    yes_rsvp_count = purrr::map_int(res, "yes_rsvp_count", .default = NA),
+    venue_id = purrr::map_int(res, c("venue", "id"), .default = NA),
+    venue_name = purrr::map_chr(res, c("venue", "name"), .default = NA),
+    venue_lat = purrr::map_dbl(res, c("venue", "lat"), .default = NA),
+    venue_lon = purrr::map_dbl(res, c("venue", "lon"), .default = NA),
+    venue_address_1 = purrr::map_chr(res, c("venue", "address_1"), .default = NA),
+    venue_city = purrr::map_chr(res, c("venue", "city"), .default = NA),
+    venue_state = purrr::map_chr(res, c("venue", "state"), .default = NA),
+    venue_zip = purrr::map_chr(res, c("venue", "zip"), .default = NA),
+    venue_country = purrr::map_chr(res, c("venue", "country"), .default = NA),
+    description = purrr::map_chr(res, c("description"), .default = NA),
+    link = purrr::map_chr(res, c("link"), .default = NA),
     resource = res
   )
 }


### PR DESCRIPTION
For example, here's a group with no organizer; 

```
r_user_group = find_groups("Durban r-user")
#> Downloading 1 record(s)...
#> Error: Result 1 is not a length 1 atomic vector
```

I replaced `.null` with `.default` because [purrr issue "Default value to replace NULL #110"](https://github.com/tidyverse/purrr/issues/110)
