### PR TITLE
align behaviour of api_key argument in get_boards

### DIFF
--- a/R/get_boards.R
+++ b/R/get_boards.R
@@ -23,7 +23,7 @@
 #'                       api_key = api_key)
 #'}
 #' @export
-get_boards <- function(urlname, api_key) {
+get_boards <- function(urlname, api_key = NULL) {
   api_method <- paste0(urlname, "/boards")
   res <- .fetch_results(api_method, api_key)
   tibble::tibble(


### PR DESCRIPTION
this tiny PR ensures consistent behaviour across all functions by adding `NULL` as default argument in `get_boards`. See issue #41 for description and reprex of the problem. :)