### PR TITLE
get_event_attendees restored, joined date for users corrected (= created date), and 400 error comment

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: meetupr
 Title: Meetup R API
-Version: 0.2.0
+Version: 0.2.1
 Authors@R: 
     c(person(given = "Gabriela",
              family = "De Queiroz",

--- a/R/get_event_attendees.R
+++ b/R/get_event_attendees.R
@@ -30,13 +30,8 @@ get_event_attendees <- function(urlname, event_id, api_key = NULL) {
   tibble::tibble(
     id = purrr::map_int(res, c("member", "id")),
     name = purrr::map_chr(res, c("member", "name")),
-    status = purrr::map_chr(res, "status"),  #currently always "attended" so this is not very useful
-    # rsvp_response = purrr::map_chr(res, c("rsvp", "response"))  #for future after fix status ^^
+    bio = purrr::map_chr(res, c("member", "bio"), .default = NA),
+    rsvp_response = purrr::map_chr(res, c("rsvp", "response")),
     resource = res
   )
 }
-
-
-
-
-

--- a/R/get_members.R
+++ b/R/get_members.R
@@ -29,10 +29,10 @@ get_members <- function(urlname, api_key = NULL){
   res <- .fetch_results(api_method, api_key)
   tibble::tibble(
     id = purrr::map_int(res, "id"),
-    name = purrr::map_chr(res, "name", .default = NA),
+    name = purrr::map_chr(res, "name", .default = NA),  
     bio = purrr::map_chr(res, "bio", .default = NA),
     status = purrr::map_chr(res, "status"),
-    joined = .date_helper(purrr::map_dbl(res, "joined")),
+    created = .date_helper(purrr::map_dbl(res, c("group_profile", "created"))),
     city = purrr::map_chr(res, "city", .default = NA),
     country = purrr::map_chr(res, "country", .default = NA),
     state = purrr::map_chr(res, "state", .default = NA),

--- a/R/internals.R
+++ b/R/internals.R
@@ -24,6 +24,15 @@ spf <- function(...) stop(sprintf(...), call. = FALSE)
                    config = meetup_token()
   )
 
+  if (req$status_code == 400) {
+    stop(paste0("HTTP 400 Bad Request error encountered for: ",
+                api_url,".\n As of June 30, 2020, this may be ",
+                "because a presumed bug with the Meetup API ",
+                "causes this error for a future event. Please ",
+                "confirm the event has ended."),
+         call. = FALSE)
+  }
+
   httr::stop_for_status(req)
   reslist <- httr::content(req, "parsed")
 


### PR DESCRIPTION
Forgive me, I need to be brief because of timelines. Please remind me if I forget to add more comments by July 4th 
I believe all of these edits have been discussed in https://github.com/rladies/meetupr/issues/67 except `get_event_attendees.R`. In `get_event_attendees.R`, I restored the returned rsvp_response that now works (maybe a prior Meetup API problem was fixed) and also show the bio now. This was needed for a presentation today (yikes).