### PR TITLE
small. changes to simplify code + fix zero return error to warning

### DIFF
--- a/R/get_events.R
+++ b/R/get_events.R
@@ -57,20 +57,21 @@
 #'}
 #' @export
 get_events <- function(urlname, event_status = "upcoming", fields = NULL, api_key = NULL) {
-  if (!is.null(event_status) &&
-     !event_status %in% c("cancelled", "draft", "past", "proposed", "suggested", "upcoming")) {
-    stop(sprintf("Event status %s not allowed", event_status))
-  }
+
+  event_status <- match.arg(event_status,
+                            c("cancelled", "draft", "past", "proposed", "suggested", "upcoming"),
+                            several.ok = TRUE)
+
   # If event_status contains multiple statuses, we can pass along a comma sep list
-  if (length(event_status) > 1) {
-    event_status <- paste(event_status, collapse = ",")
-  }
+  event_status <- paste(event_status, collapse = ",")
+
   # If fields is a vector, change it to single string of comma separated values
-  if(length(fields) > 1){
-    fields <- paste(fields, collapse = ",")
-  }
+  fields <- paste(fields, collapse = ",")
+
   api_method <- paste0(urlname, "/events")
+
   res <- .fetch_results(api_method, api_key, event_status, fields = fields)
+
   tibble::tibble(
     id = purrr::map_chr(res, "id"),  #this is returned as chr (not int)
     name = purrr::map_chr(res, "name"),

--- a/R/internals.R
+++ b/R/internals.R
@@ -40,7 +40,7 @@ spf <- function(...) stop(sprintf(...), call. = FALSE)
   reslist <- httr::content(req, "parsed")
 
   if (length(reslist) == 0) {
-    stop("Zero records match your filter. Nothing to return.\n",
+    warning("Zero records match your filter. Nothing to return.\n",
          call. = FALSE)
   }
 

--- a/R/internals.R
+++ b/R/internals.R
@@ -42,6 +42,7 @@ spf <- function(...) stop(sprintf(...), call. = FALSE)
   if (length(reslist) == 0) {
     warning("Zero records match your filter. Nothing to return.\n",
          call. = FALSE)
+    return(NULL)
   }
 
   return(list(result = reslist, headers = req$headers))

--- a/R/internals.R
+++ b/R/internals.R
@@ -64,12 +64,7 @@ meetup_api_prefix <- function() {
 # API Methods listed here: https://www.meetup.com/meetup_api/docs/
 .fetch_results <- function(api_method, api_key = NULL, event_status = NULL, ...) {
 
-  # Build the API endpoint URL
-  # meetup_api_prefix <- meetup_api_prefix()
-  # api_url <- httr::modify_url(meetup_api_prefix, path = api_method)
-
-  # Fetch first set of results (limited to 200 records each call)
-
+    # Fetch first set of results (limited to 200 records each call)
   res <- .quick_fetch(api_method = api_method,
                       api_key = api_key,
                       event_status = event_status,

--- a/R/internals.R
+++ b/R/internals.R
@@ -42,7 +42,7 @@ spf <- function(...) stop(sprintf(...), call. = FALSE)
   if (length(reslist) == 0) {
     warning("Zero records match your filter. Nothing to return.\n",
          call. = FALSE)
-    return(NULL)
+    invisible(NULL)
   }
 
   return(list(result = reslist, headers = req$headers))

--- a/R/internals.R
+++ b/R/internals.R
@@ -3,7 +3,7 @@ spf <- function(...) stop(sprintf(...), call. = FALSE)
 
 # This helper function makes a single call, given the full API endpoint URL
 # Used as the workhorse function inside .fetch_results() below
-.quick_fetch <- function(api_url,
+.quick_fetch <- function(api_method,
                          api_key = NULL, # deprecated, unused, can't swallow this in `...`
                          event_status = NULL,
                          offset = 0,
@@ -21,14 +21,15 @@ spf <- function(...) stop(sprintf(...), call. = FALSE)
     parameters <- append(parameters, list(key = get_api_key()))
   }
 
-  req <- httr::GET(url = api_url,          # the endpoint
+  req <- httr::GET(url = meetup_api_prefix(),          # the endpoint
+                   path = api_method,
                    query = parameters,
                    config = meetup_token()
   )
 
   if (req$status_code == 400) {
     stop(paste0("HTTP 400 Bad Request error encountered for: ",
-                api_url,".\n As of June 30, 2020, this may be ",
+                api_method,".\n As of June 30, 2020, this may be ",
                 "because a presumed bug with the Meetup API ",
                 "causes this error for a future event. Please ",
                 "confirm the event has ended."),
@@ -63,18 +64,18 @@ meetup_api_prefix <- function() {
 .fetch_results <- function(api_method, api_key = NULL, event_status = NULL, ...) {
 
   # Build the API endpoint URL
-  meetup_api_prefix <- meetup_api_prefix()
-  api_url <- httr::modify_url(meetup_api_prefix, path = api_method)
+  # meetup_api_prefix <- meetup_api_prefix()
+  # api_url <- httr::modify_url(meetup_api_prefix, path = api_method)
 
   # Fetch first set of results (limited to 200 records each call)
 
-  res <- .quick_fetch(api_url = api_url,
+  res <- .quick_fetch(api_method = api_method,
                       api_key = api_key,
                       event_status = event_status,
                       offset = 0,
                       ...)
 
-  res <-  .quick_fetch(api_url, event_status = event_status, ...)
+  res <-  .quick_fetch(api_method, event_status = event_status, ...)
 
 
   # Total number of records matching the query
@@ -90,7 +91,7 @@ meetup_api_prefix <- function() {
     all_records <- list(records)
 
     for(i in 1:(offsetn - 1)) {
-      res <- .quick_fetch(api_url = api_url,
+      res <- .quick_fetch(api_method = api_method,
                           api_key = api_key,
                           event_status = event_status,
                           offset = i,

--- a/tests/testthat/test-get_events.R
+++ b/tests/testthat/test-get_events.R
@@ -16,7 +16,6 @@ test_that("get_events() works with one status", {
     all(
       names(past_events) == expected_names
     ))
-
 })
 
 test_that("get_events() works with multiple statuses", {

--- a/tests/testthat/test-get_events.R
+++ b/tests/testthat/test-get_events.R
@@ -38,7 +38,7 @@ test_that("get_events() has informative error messages", {
   urlname <- "rladies-johannesburg"
   expect_error(
     get_events(urlname = urlname, event_status = "pasttt"),
-    "not allowed"
+    "should be one of"
     )
   expect_error(
     get_events(event_status = "past")

--- a/tests/testthat/test-internals.R
+++ b/tests/testthat/test-internals.R
@@ -1,8 +1,8 @@
 test_that(".quick_fetch() success case", {
-  api_url <- httr::modify_url(meetup_api_prefix(), path = "rladies-nashville/events")
+  api_method <- "rladies-nashville/events"
   vcr::use_cassette("quick_fetch", {
     res <- .quick_fetch(
-      api_url = api_url,
+      api_method = api_method,
       event_status = "past"
       )
   })


### PR DESCRIPTION
Rather than throwing an error when zero records are found, throw a warning and return invisible NULL. 
Makes is possible to run with apply's without erroring. 

Also, small changes to the code for simplification:
- replace `if` statement in get events for checking event_status to `match.arg`  
- change so that httr:GET path argument is used to collate api url and api_method, rather than pasting before.

One test is still failing, but I dont really understand vcr, so I'm not able to figure out what is going on. 