### PR TITLE
fix bug in fetching more than 200 records

### DIFF
--- a/R/internals.R
+++ b/R/internals.R
@@ -94,6 +94,7 @@ meetup_api_prefix <- function() {
                           ...)
 
       next_url <- strsplit(strsplit(res$headers$link, split = "<")[[1]][2], split = ">")[[1]][1]
+      next_url <- gsub(meetup_api_prefix(), "", next_url)
       res <- .quick_fetch(next_url, event_status)
 
       all_records[[i + 1]] <- res$result


### PR DESCRIPTION
when introducing the new way of quering the api with httr::GET and path, we broke part of the pipeline that incrementally gets records by 200. 

This is fixed by this line.