### PR TITLE
more automatic rate limiting

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -56,6 +56,7 @@ License: MIT + file LICENSE
 Depends:
     R (>= 3.5)
 Imports:
+    ratelimitr,
     httr,
     purrr,
     tibble,

--- a/R/internals.R
+++ b/R/internals.R
@@ -44,7 +44,7 @@ spf <- function(...) stop(sprintf(...), call. = FALSE)
   assign(
     "meetupr_rate",
     c(headers$`x-ratelimit-limit`, headers$`x-ratelimit-reset`),
-    envir=.meetupr_env
+    envir = .meetupr_env
     )
 
   reslist <- httr::content(req, "parsed")

--- a/tests/testthat/test-internals.R
+++ b/tests/testthat/test-internals.R
@@ -1,7 +1,7 @@
-test_that(".quick_fetch() success case", {
+test_that("meetup_call() success case", {
   api_method <- "rladies-nashville/events"
   vcr::use_cassette("quick_fetch", {
-    res <- .quick_fetch(
+    res <- meetup_call(
       api_method = api_method,
       event_status = "past"
       )


### PR DESCRIPTION
Fix #9 

This PR

* renames the .quick_fetch function as it's not really quick. Its name no longer starts with a dot, as preparation for #82 
* uses ratelimitr for limiting the rate.

The default rate limit (30 requests per slot of 10 seconds) is what I've observed in headers. I update it after every API call. All of this because the Meetup API docs do not document how the rate could change. https://www.meetup.com/meetup_api/#limits

Example of code that would fail with the current package version but is automatically paced with this PR

```r
for (i in 1:50) {
  lala <- get_events("rladies-nashville")
  print(Sys.time())
}
```