### PR TITLE
Set up `gh` for GraphQL calls to meetup.com

### DIFF
--- a/.github/workflows/with-auth.yaml
+++ b/.github/workflows/with-auth.yaml
@@ -8,7 +8,7 @@ name: with-auth
 
 jobs:
   with-auth:
-    runs-on: macOS-latest
+    runs-on: macos-latest
 
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,6 +27,8 @@ Imports:
     ratelimitr,
     httr,
     purrr,
+    gh,
+    progress,
     tibble,
     rlang,
     rappdirs

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,7 +31,8 @@ Imports:
     progress,
     tibble,
     rlang,
-    rappdirs
+    rappdirs,
+    glue
 Suggests:
     dplyr,
     sodium,

--- a/R/graphql.R
+++ b/R/graphql.R
@@ -1,0 +1,197 @@
+# There is funnyness in how many items are queried.
+# If single event has query size 80, Data Viz DC gets 121.
+# If query size is 100, the total size is 119
+# The result size is consistent, but it is not an off-by-one error.
+# IDK. Punting for now, but it should be addressed
+
+
+capture_str <- function(x) {
+  paste0(
+    capture.output(str(x)),
+    collapse = "\n"
+  )
+}
+
+
+graphql_query <- function(graphql_file, ...) {
+  # inspiration: https://github.com/tidyverse/tidyversedashboard/blob/2c6cf9ebe8da938c35f6e9fc184c3b30265f1082/R/utils.R#L2
+  file <- system.file(file.path("graphql", paste0(graphql_file, ".graphql")), package = "meetupr")
+  query <- readChar(file, file.info(file)$size)
+  variables <- purrr::compact(rlang::list2(...))
+  if (!rlang::is_named(variables)) {
+    stop("Stop all GraphQL variables must be named. Variables:\n", capture_str(variables), call. = FALSE)
+  }
+  # str(variables)
+  suppressMessages({
+    # Stop printing of message: `No encoding supplied: defaulting to UTF-8.`
+    # Message comes deep within gh:::gh_process_response via `content(response, as = "text")` should have `encode = "UTF-8"` param
+    response <- gh::gh(
+      "POST https://api.meetup.com/gql",
+      query = query,
+      variables = variables,
+      .accept = "application/json",
+      .send_headers = c(
+        "Authorization" = paste0("Bearer ", meetup_token()$auth_token$credentials$access_token)
+      )
+    )
+  })
+
+  if (!is.null(response$errors)) {
+    stop("Meetup GraphQL API returned errors.\n",capture_str(response$errors))
+  }
+  response
+}
+
+graphql_query_generator <- function(
+  graphql_file,
+  cursor_fn,
+  extract_fn,
+  total_fn,
+  combiner_fn
+) {
+  force(graphql_file)
+  force(cursor_fn)
+  force(extract_fn)
+  force(total_fn)
+  force(combiner_fn)
+
+  function(
+    ...
+  ) {
+    ret <- NULL
+    cursors <- list()
+    pb <- NULL
+    while (TRUE) {
+      # browser()
+      graphql_res <- graphql_query(graphql_file, ..., !!!cursors)
+      cursors <- cursor_fn(graphql_res)
+      graphql_content <- extract_fn(graphql_res)
+      if (is.null(pb)) {
+        pb <- progress::progress_bar$new(
+          total = total_fn(graphql_res),
+          format = paste0(graphql_file, " [:bar] :current/:total :eta"),
+          show_after = 0
+        )
+        on.exit({
+          # Make sure the pb is closed when exiting
+          pb$terminate()
+        }, add = TRUE)
+      }
+
+      ret <- combiner_fn(ret, graphql_content)
+      pb$tick(length(graphql_content))
+
+      # If there is no more data to traverse, quit
+      if (length(cursors) == 0) break
+    }
+
+    ret
+  }
+}
+
+
+gql_health_check <- graphql_query_generator(
+  "health_check",
+  cursor_fn = function(response) {
+    NULL
+  },
+  extract_fn = function(x) {
+    x$data$healthCheck
+  },
+  total_fn = function(x) {
+    1
+  },
+  combiner_fn = append
+)
+
+# gql_single_event <- graphql_query_generator(
+#   "single_event",
+#   cursor_fn = function(response) {
+#     # str(response, max.level = 5)
+#     pageInfo <- response$data$groupByUrlname$pastEvents$pageInfo
+#     # str(pageInfo)
+#     if (pageInfo$hasNextPage) {
+#       list(cursor = pageInfo$endCursor)
+#     } else {
+#       NULL
+#     }
+#   },
+#   extract_fn = function(x) {
+#     x$data$groupByUrlname$pastEvents$edges
+#   },
+#   total_fn = function(x) {
+#     x$data$groupByUrlname$pastEvents$count
+#   },
+#   combiner_fn = append
+# )
+
+gql_single_event <- graphql_query_generator(
+  "single_event",
+  cursor_fn = function(response) {
+    groupByUrlname <- response$data$groupByUrlname
+    unifiedEventsInfo <- groupByUrlname$unifiedEvents$pageInfo
+    upcomingEventsInfo <- groupByUrlname$upcomingEvents$pageInfo
+    pastEventsInfo <- groupByUrlname$pastEvents$pageInfo
+
+    ret <- list()
+    hasACursor <- FALSE
+    add_cursor_info <- function(info, name) {
+      if (!is.null(info) && info$hasNextPage) {
+        hasACursor <<- TRUE
+        ret[[paste0("cursor", name)]] <<- info$endCursor
+      } else {
+        ret[[paste0("query", name)]] <<- FALSE
+      }
+    }
+    add_cursor_info(unifiedEventsInfo, "Unified")
+    add_cursor_info(upcomingEventsInfo, "Upcoming")
+    add_cursor_info(pastEventsInfo, "Past")
+
+    if (hasACursor) {
+      ret
+    } else {
+      NULL
+    }
+  },
+  extract_fn = function(x) {
+    # browser()
+    groupByUrlname <- x$data$groupByUrlname
+
+    unifiedEvents <- groupByUrlname$unifiedEvents$edges
+    upcomingEvents <- groupByUrlname$upcomingEvents$edges
+    pastEvents <- groupByUrlname$pastEvents$edges
+
+    unifiedEvents <- lapply(unifiedEvents, `[[<-`, "type", "unified")
+    upcomingEvents <- lapply(upcomingEvents, `[[<-`, "type", "upcoming")
+    pastEvents <- lapply(pastEvents, `[[<-`, "type", "past")
+
+    # str(list(
+    #   unifiedLength = length(unifiedEvents),
+    #   upcomingLength = length(upcomingEvents),
+    #   pastLength = length(pastEvents)
+    # ))
+
+    ret <-
+      append(
+        append(unifiedEvents, upcomingEvents),
+        pastEvents,
+      )
+    ret
+  },
+  total_fn = function(x) {
+    groupByUrlname <- x$data$groupByUrlname
+    sum(c(
+      groupByUrlname$unifiedEvents$count,
+      groupByUrlname$upcomingEvents$count,
+      groupByUrlname$pastEvents$count
+    ))
+  },
+  combiner_fn = append
+)
+
+if (FALSE) {
+  x <- gql_single_event()
+  x <- gql_single_event(urlname = "Data-Visualization-DC")
+  x <- gql_single_event(urlname = "R-Users")
+  x <- gql_single_event(urlname = "Data-Science-DC")
+}

--- a/R/graphql.R
+++ b/R/graphql.R
@@ -3,6 +3,12 @@
 # If query size is 100, the total size is 119
 # The result size is consistent, but it is not an off-by-one error.
 # IDK. Punting for now, but it should be addressed
+# ```r
+# x <- gql_single_event(urlname = "Data-Visualization-DC", firstPast =  80, queryUnified = FALSE, queryUpcoming = FALSE)
+# y <- gql_single_event(urlname = "Data-Visualization-DC", firstPast = 100, queryUnified = FALSE, queryUpcoming = FALSE)
+# testthat::expect_equal(x %in% y, rep(TRUE, length(x))) # NOT TRUE!!!
+# testthat::expect_equal(y %in% x, rep(TRUE, length(y))) # TRUE
+# ```
 
 
 capture_str <- function(x) {
@@ -22,6 +28,21 @@ graphql_query <- function(graphql_file, ...) {
     stop("Stop all GraphQL variables must be named. Variables:\n", capture_str(variables), call. = FALSE)
   }
   # str(variables)
+
+  ## From meetup.com website example:
+  # query='query { self { id name } }'
+
+  # curl -X POST https://api.meetup.com/gql \
+  #   -H 'Authorization: Bearer {YOUR_TOKEN}' \
+  #   -H 'Content-Type: application/json' \
+  #   -d @- <<EOF
+  #     {
+  #       "query": "query { self { id name } }",
+  #       "variables": "{\"foo\": \"bar\"}"
+  #     }
+  # EOF
+
+
   suppressMessages({
     # Stop printing of message: `No encoding supplied: defaulting to UTF-8.`
     # Message comes deep within gh:::gh_process_response via `content(response, as = "text")` should have `encode = "UTF-8"` param
@@ -189,9 +210,15 @@ gql_single_event <- graphql_query_generator(
   combiner_fn = append
 )
 
+
+
+
 if (FALSE) {
-  x <- gql_single_event()
+  x <- gql_health_check()
+
   x <- gql_single_event(urlname = "Data-Visualization-DC")
   x <- gql_single_event(urlname = "R-Users")
   x <- gql_single_event(urlname = "Data-Science-DC")
+
+
 }

--- a/R/graphql.R
+++ b/R/graphql.R
@@ -13,7 +13,7 @@
 
 capture_str <- function(x) {
   paste0(
-    capture.output(str(x)),
+    utils::capture.output(utils::str(x)),
     collapse = "\n"
   )
 }

--- a/inst/graphql/health_check.graphql
+++ b/inst/graphql/health_check.graphql
@@ -1,0 +1,3 @@
+query healthCheck {
+  healthCheck
+}

--- a/inst/graphql/single_event.graphql
+++ b/inst/graphql/single_event.graphql
@@ -78,5 +78,5 @@ fragment eventFields on Event {
   }
   description
   eventUrl
-  # $ExtraFields
+  << extra_graphql >>
 }

--- a/inst/graphql/single_event.graphql
+++ b/inst/graphql/single_event.graphql
@@ -1,0 +1,82 @@
+query singleEvent(
+  $urlname: String! = "Data-Visualization-DC"
+  $cursorUnified: String
+  $cursorUpcoming: String
+  $cursorPast: String
+  $queryUnified: Boolean = true
+  $queryUpcoming: Boolean = true
+  $queryPast: Boolean = true
+  $firstUnified: Int = 10000
+  $firstUpcoming: Int = 10000
+  $firstPast: Int = 10000
+) {
+  groupByUrlname(urlname: $urlname) {
+    id
+    unifiedEvents(input: { first: $firstUnified, after: $cursorUnified })
+      @include(if: $queryUnified) {
+      pageInfo {
+        ...pageInfos
+      }
+      count
+      edges {
+        cursor
+        node {
+          ...eventFields
+        }
+      }
+    }
+    upcomingEvents(input: { first: $firstUpcoming, after: $cursorUpcoming })
+      @include(if: $queryUpcoming) {
+      pageInfo {
+        ...pageInfos
+      }
+      count
+      edges {
+        cursor
+        node {
+          ...eventFields
+        }
+      }
+    }
+    pastEvents(input: { first: $firstPast, after: $cursorPast })
+      @include(if: $queryPast) {
+      pageInfo {
+        ...pageInfos
+      }
+      count
+      edges {
+        cursor
+        node {
+          ...eventFields
+        }
+      }
+    }
+  }
+}
+
+fragment pageInfos on PageInfo {
+  hasNextPage
+  # hasPreviousPage
+  # startCursor
+  endCursor
+}
+fragment eventFields on Event {
+  id
+  title
+  eventUrl
+  dateTime
+  createdAt
+  going
+  waiting
+  venue {
+    name
+    address
+    city
+    state
+    postalCode
+    country
+  }
+  description
+  eventUrl
+  # $ExtraFields
+}


### PR DESCRIPTION
Uses `{gh::gh()}` under the hood, not `{httr::POST()}`.

Queries are run through `{glue::glue_data(list(extra_graphql=extra_graphql), query)}` to add fields not originally in the query.

Ex:

```r
❯❯ regular <- gql_single_event(urlname = "Data-Science-DC")

❯❯ bigger <- gql_single_event(urlname = "Data-Science-DC", extra_graphql = "host { name }")

❯❯ length(regular)
[1] 127
```

```r
❯❯ str(regular[[127]])
List of 10
 $ id         : chr "281553470!chp"
 $ title      : chr "Apache Iceberg - An Architectural Look Under the Covers"
 $ eventUrl   : chr "https://www.meetup.com/Data-Science-DC/events/281553470"
 $ dateTime   : chr "2021-11-09T18:00-05:00"
 $ createdAt  : NULL
 $ going      : int 89
 $ waiting    : int 0
 $ venue      :List of 6
  ..$ name      : chr "Online event"
  ..$ address   : chr ""
  ..$ city      : chr ""
  ..$ state     : chr ""
  ..$ postalCode: chr ""
  ..$ country   : chr ""
 $ description: chr "Data Lakes were built with a desire to democratize data - to allow more and more people, tools, and application"| __truncated__
 $ type       : chr "past"
```

```r
❯❯ str(bigger[[127]])
List of 11
 $ id         : chr "281553470!chp"
 $ title      : chr "Apache Iceberg - An Architectural Look Under the Covers"
 $ eventUrl   : chr "https://www.meetup.com/Data-Science-DC/events/281553470"
 $ dateTime   : chr "2021-11-09T18:00-05:00"
 $ createdAt  : NULL
 $ going      : int 89
 $ waiting    : int 0
 $ venue      :List of 6
  ..$ name      : chr "Online event"
  ..$ address   : chr ""
  ..$ city      : chr ""
  ..$ state     : chr ""
  ..$ postalCode: chr ""
  ..$ country   : chr ""
 $ description: chr "Data Lakes were built with a desire to democratize data - to allow more and more people, tools, and application"| __truncated__
 $ host       :List of 1
  ..$ name: chr "Tommy Jones"
 $ type       : chr "past"
```