### PR TITLE
GraphQL: Flatten all lists into combined names to make a tibble

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,9 +32,10 @@ Imports:
     tibble,
     rlang,
     rappdirs,
-    glue
-Suggests:
+    glue,
     dplyr,
+    rlist
+Suggests:
     sodium,
     cyphr,
     knitr,

--- a/R/graphql.R
+++ b/R/graphql.R
@@ -4,8 +4,8 @@
 # The result size is consistent, but it is not an off-by-one error.
 # IDK. Punting for now, but it should be addressed
 # ```r
-# x <- gql_single_event(urlname = "Data-Visualization-DC", firstPast =  80, queryUnified = FALSE, queryUpcoming = FALSE)
-# y <- gql_single_event(urlname = "Data-Visualization-DC", firstPast = 100, queryUnified = FALSE, queryUpcoming = FALSE)
+# x <- gql_events(urlname = "Data-Visualization-DC", firstPast =  80, queryUnified = FALSE, queryUpcoming = FALSE)
+# y <- gql_events(urlname = "Data-Visualization-DC", firstPast = 100, queryUnified = FALSE, queryUpcoming = FALSE)
 # testthat::expect_equal(x %in% y, rep(TRUE, length(x))) # NOT TRUE!!!
 # testthat::expect_equal(y %in% x, rep(TRUE, length(y))) # TRUE
 # ```
@@ -159,7 +159,7 @@ gql_health_check <- graphql_query_generator(
 # )
 
 gql_single_event <- graphql_query_generator(
-  "single_event",
+  "find_events",
   cursor_fn = function(x) {
     groupByUrlname <- x$data$groupByUrlname
     unifiedEventsInfo <- groupByUrlname$unifiedEvents$pageInfo
@@ -320,16 +320,14 @@ add_group_locations <- function(groups) {
 if (FALSE) {
   x <- gql_health_check()
 
-  x <- gql_single_event(urlname = "Data-Visualization-DC")
-  x <- gql_single_event(urlname = "R-Users")
+  x <- gql_events(urlname = "Data-Visualization-DC")
+  x <- gql_events(urlname = "R-Users")
 
-  x <- gql_single_event(urlname = "Data-Science-DC")
+  x <- gql_events(urlname = "Data-Science-DC")
 
-  x <- gql_single_event(urlname = "Data-Science-DC", extra_graphql = "host { name }")
+  x <- gql_events(urlname = "Data-Science-DC", extra_graphql = "host { name }")
 
   x <- graphql_file("location", lat = 10.54, lon = -66.93)
 
   x <- gql_find_groups(topicCategoryId = 546, query = "R-Ladies")
-
-
 }

--- a/inst/graphql/find_events.graphql
+++ b/inst/graphql/find_events.graphql
@@ -66,7 +66,7 @@ fragment eventFields on Event {
   title
   eventUrl
   dateTime
-  createdAt
+  # createdAt
   going
   waiting
   venue {


### PR DESCRIPTION
Ex code: 
```r
tibble::glimpse(gql_events(urlname = "Data-Visualization-DC"))
```
```
Rows: 122
Columns: 14
$ id               <chr> "277393114!chp", "103349942!chp", "107867022!chp", "109083742!chp", "113825602!chp", "1204385…
$ title            <chr> "Data Viz DC Monthly Meetup", "Ecosystem GIS & Community Building", "Data Shamrock", "Data Ps…
$ eventUrl         <chr> "https://www.meetup.com/Data-Visualization-DC/events/277393114", "https://www.meetup.com/Data…
$ dateTime         <chr> "2021-05-13T18:00-04:00", "2013-02-18T18:30-05:00", "2013-03-09T13:00-05:00", "2013-03-25T18:…
$ going            <int> 5, 97, 8, 139, 160, 190, 224, 138, 20, 355, 193, 231, 130, 199, 218, 33, 34, 135, 217, 173, 1…
$ waiting          <int> 0, 0, 0, 4, 17, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 30, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 93, 41, 42…
$ venue.name       <chr> "Online event", "Browsermedia/NClud", "Mad Rose Tavern", "Browsermedia/NClud", "iStrategyLabs…
$ venue.address    <chr> "", "1203 19th Street", "3100 Clarendon Blvd.", "1203 19th Street", "641 S St NW", "1424 K St…
$ venue.city       <chr> "", "Washington", "Arlington", "Washington", "Washington", "Washington", "Washington", "Washi…
$ venue.state      <chr> "", "DC", "VA", "DC", "DC", "DC", "DC", "DC", "DC", "DC", "DC", "DC", "DC", "DC", "DC", "DC",…
$ venue.postalCode <chr> "", "20036", "22201", "20036", "20001", "20005", "20005", "20005", "20005", "20005", "20005",…
$ venue.country    <chr> "", "us", "us", "us", "us", "us", "us", "us", "us", "us", "us", "us", "us", "us", "us", "us",…
$ description      <chr> "Data Visualization DC Monthly Meetup -- Every 2nd Thursday\n\nJoin Data Viz DC for our month…
$ eventType        <chr> "unified", "past", "past", "past", "past", "past", "past", "past", "past", "past", "past", "p…
```

Note that `venue.name` was originally nested data like `rowData$venue$name`. Now it is flattened for usage.