### PR TITLE
Fix failing `get_event_attendees()` test

### DIFF
--- a/inst/graphql/find_attendees.graphql
+++ b/inst/graphql/find_attendees.graphql
@@ -26,7 +26,6 @@ query eventAttendee(
               baseUrl
             }
             joinTime
-            timezone
             organizedGroupCount
             << extra_graphql >>
           }

--- a/tests/testthat/test-get_event_attendees.R
+++ b/tests/testthat/test-get_event_attendees.R
@@ -1,13 +1,11 @@
-expected_names <- c("id", "name", "url", "photo", "organized_group_count")
-
 test_that("get_events_attendees() works with one status", {
+
+  expected_names <- c("id", "name", "url", "photo", "organized_group_count")
+
   vcr::use_cassette("get_event_attendees", {
     attendees <-  get_event_attendees(id = "103349942")
   })
   expect_s3_class(attendees, "data.frame")
 
-  expect_true(
-    all(
-      names(attendees) == expected_names
-    ))
+  expect_setequal(expected_names, names(attendees))
 })


### PR DESCRIPTION
The test for `get_event_attendees()` was failing because there was an extra field (`timezone`) returned, which wasn't expected.

The comparison was also issuing a warning.

In this PR, I:
* updated the query so it doesn't return the timezone field - I'm guessing we don't want this field, but I could refactor the tests to expect this field if we do
* update the test to use `expect_setequal()` so we don't get an additional warning if the test fails