### PR TITLE
Use rladiesdocs pkgdown template

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -71,4 +71,4 @@ Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.3
 URL: https://rladies.org/meetupr/
-BugReports: https://github.com/rladies/meetupr/issues
+BugReports: https://github.com/rladies/meetupr/issuesConfig/Needs/website: rladies/rladiesdocs

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,6 +1,7 @@
+url: https://rladies.org/meetupr/
 template:
+  package: rladiesdocs
   bootstrap: 5
-url: http://rladies.org/meetupr/
 
 logo:
   image: man/figures/logo.png


### PR DESCRIPTION
## Summary
- Updates `_pkgdown.yml` to use `template: package: rladiesdocs` for the RLadies+ branded pkgdown theme
- Removes custom bslib config (now provided by rladiesdocs)
- Updates URL to HTTPS
- Adds `Config/Needs/website: rladies/rladiesdocs` to DESCRIPTION

## Test plan
- [ ] Install rladiesdocs: `pak::pak("rladies/rladiesdocs")`
- [ ] Build site: `pkgdown::build_site()`
- [ ] Verify RLadies+ branding (purple theme, Poppins fonts, light/dark toggle)
- [ ] Verify custom reference sections and articles still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)