### PR TITLE
Adopt jinx reusable workflows for welcome and thank

### DIFF
--- a/.github/workflows/hello.yaml
+++ b/.github/workflows/hello.yaml
@@ -6,6 +6,10 @@ on:
   issues:
     types: [opened]
 
+permissions:
+  contents: read
+  packages: read
+
 jobs:
   welcome:
     if: github.event.action == 'opened'

--- a/.github/workflows/hello.yaml
+++ b/.github/workflows/hello.yaml
@@ -1,0 +1,22 @@
+name: Hello on PR or Issue
+
+on:
+  pull_request:
+    types: [opened, closed]
+  issues:
+    types: [opened]
+
+jobs:
+  welcome:
+    if: github.event.action == 'opened'
+    uses: rladies/jinx/.github/workflows/reusable-welcome-contributor.yml@main
+    secrets:
+      JINX_APP_ID: ${{ secrets.JINX_APP_ID }}
+      JINX_PRIVATE_KEY: ${{ secrets.JINX_PRIVATE_KEY }}
+
+  thank:
+    if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true
+    uses: rladies/jinx/.github/workflows/reusable-thank-contributor.yml@main
+    secrets:
+      JINX_APP_ID: ${{ secrets.JINX_APP_ID }}
+      JINX_PRIVATE_KEY: ${{ secrets.JINX_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary

Adds `hello.yaml` that delegates to the [rladies/jinx](https://github.com/rladies/jinx) reusable workflows so first-time PR/issue contributors get a welcome comment, and merged PRs get a thank-you. Same pattern as [rladies/rladies.github.io#592](https://github.com/rladies/rladies.github.io/pull/592).

`JINX_APP_ID` and `JINX_PRIVATE_KEY` are already available org-wide; no per-repo secret configuration needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)